### PR TITLE
fix(validation): class-validation not throwing error on failure

### DIFF
--- a/src/common/request/request.module.ts
+++ b/src/common/request/request.module.ts
@@ -43,7 +43,7 @@ export class RequestModule {
                     useFactory: () =>
                         new ValidationPipe({
                             transform: true,
-                            skipUndefinedProperties: true,
+                            skipUndefinedProperties: false,
                             forbidUnknownValues: true,
                             errorHttpStatusCode:
                                 HttpStatus.UNPROCESSABLE_ENTITY,


### PR DESCRIPTION
While investigating a recurring issue with server-side validation errors bubbling up as 500 Internal Server Error, I noticed the following configuration in our `ValidationPipe:`

```javascript
// src/common/request/request.module.ts
new ValidationPipe({
  skipUndefinedProperties: false,
})
```

This means when a client omits required fields (leaves a field out of the request body), `class-validator` will not raise a validation error. 
Instead, the request passes through to the controller and hits the business logic, which can lead to runtime errors like:

```
{
  "statusCode": 500,
  "message": "Internal Server Error",
  "_metadata": {
    "language": "en",
    "timestamp": 1750951771806,
    "timezone": "Asia/Jakarta",
    "path": "/api/v1/admin/terms-policy",
    "version": "1",
    "repoVersion": "7.4.2"
  }
}
```

And on server-side logs:

```
ERROR [2025-06-26 22:29:31.806 +0700]: TermsPolicyEntity validation failed: country: Path `country` is required.
....
    err: {
      "message": "TermsPolicyEntity validation failed: country: Path `country` is required.",
      "stack":
          ValidationError: TermsPolicyEntity validation failed: country: Path `country` is required.
              at Document.invalidate (/Users/dantoniolc/ghq/github.com/Gzerox/ack-nestjs-boilerplate/node_modules/mongoose/lib/document.js:3352:32)
              at /Users/dantoniolc/ghq/github.com/Gzerox/ack-nestjs-boilerplate/node_modules/mongoose/lib/document.js:3113:17
              at /Users/dantoniolc/ghq/github.com/Gzerox/ack-nestjs-boilerplate/node_modules/mongoose/lib/schemaType.js:1407:9
              at process.processTicksAndRejections (node:internal/process/task_queues:85:11)
    }
```

This error is actually coming from Mongoose, not class-validator, which is a clear sign the DTO layer didn’t catch the issue early enough.

---

However, I did notice that this setting (`skipUndefinedProperties: false`) has been in place for quite a long time. 
So before jumping to conclusions, I wanted to double-check: am I missing some intentional behavior or edge case that relies on this?

If there’s a valid reason it was kept `false`, I’m happy to learn why and close this PR.
Just wanted to raise this since the current behavior leads to confusing errors and could be safely handled earlier at the validation stage.