### PR TITLE
fix(pagination): page evaluation

### DIFF
--- a/src/common/pagination/pipes/pagination.cursor.pipe.ts
+++ b/src/common/pagination/pipes/pagination.cursor.pipe.ts
@@ -35,8 +35,9 @@ export function PaginationCursorPipe(
                 perPage?: number | string;
             } & IPaginationQueryCursorParams
         ): Promise<IPaginationQueryCursorParams> {
-            const finalPerPage =
-                Number.parseInt(value.perPage?.toString()) ?? defaultPerPage;
+            const finalPerPage = Number.isFinite(value?.perPage)
+                ? Number(value?.perPage)
+                : defaultPerPage;
             this.addToRequestInstance(finalPerPage, value.cursor);
 
             return {

--- a/src/common/pagination/pipes/pagination.offset.pipe.ts
+++ b/src/common/pagination/pipes/pagination.offset.pipe.ts
@@ -34,8 +34,12 @@ export function PaginationOffsetPipe(
                 perPage?: number | string;
             } & IPaginationQueryOffsetParams
         ): Promise<IPaginationQueryOffsetParams> {
-            let finalPage = Number(value.page) ?? 1;
-            let finalPerPage = Number(value.perPage) ?? defaultPerPage;
+            let finalPage = Number.isFinite(value.page)
+                ? Number(value.page)
+                : 1;
+            let finalPerPage = Number.isFinite(value.perPage)
+                ? Number(value.perPage)
+                : defaultPerPage;
 
             if (finalPage > PaginationDefaultMaxPage) {
                 finalPage = PaginationDefaultMaxPage;


### PR DESCRIPTION
fixes scenario in which the user does not provide `page` and/or `perPage` parameters via url query.

In such scenarios the check was returning `NaN` instead of the intended default value, this breaks then the query which complains about the missing "limit/take" parameter, 