### PR TITLE
fix(term-policy): json override

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,7 +124,7 @@ model User {
   lastIPAddress   String?
   lastLoginFrom   EnumUserLoginFrom?
   lastLoginWith   EnumUserLoginWith?
-  termPolicy      Json
+  termPolicy      UserTermPolicy
   photo           Json?
 
   // timestamps fields
@@ -352,6 +352,13 @@ model ForgotPassword {
   @@index(fields: [token, expiredAt, isUsed])
   @@index(fields: [token])
   @@map("ForgotPasswords")
+}
+
+type UserTermPolicy {
+  termsOfService Boolean
+  privacy        Boolean
+  marketing      Boolean
+  cookies        Boolean
 }
 
 enum EnumUserGender {

--- a/src/modules/term-policy/controllers/term-policy.shared.controller.ts
+++ b/src/modules/term-policy/controllers/term-policy.shared.controller.ts
@@ -7,7 +7,10 @@ import {
     HttpStatus,
     Post,
 } from '@nestjs/common';
-import { UserProtected } from '@modules/user/decorators/user.decorator';
+import {
+    UserCurrent,
+    UserProtected,
+} from '@modules/user/decorators/user.decorator';
 import {
     AuthJwtAccessProtected,
     AuthJwtPayload,
@@ -36,6 +39,7 @@ import {
 } from '@common/request/decorators/request.decorator';
 import { RequestUserAgentDto } from '@common/request/dtos/request.user-agent.dto';
 import { TermPolicyAcceptanceProtected } from '@modules/term-policy/decorators/term-policy.decorator';
+import { IUser } from '@modules/user/interfaces/user.interface';
 
 @ApiTags('modules.shared.user.termPolicy')
 @Controller({
@@ -69,12 +73,12 @@ export class TermPolicySharedController {
     @HttpCode(HttpStatus.OK)
     @Post('/accept')
     async accept(
-        @AuthJwtPayload('userId') userId: string,
+        @UserCurrent() user: IUser,
         @Body() body: TermPolicyAcceptRequestDto,
         @RequestIPAddress() ipAddress: string,
         @RequestUserAgent() userAgent: RequestUserAgentDto
     ): Promise<IResponseReturn<void>> {
-        return this.termPolicyService.userAccept(userId, body, {
+        return this.termPolicyService.userAccept(user.id, body, user.termPolicy, {
             ipAddress,
             userAgent,
         });

--- a/src/modules/term-policy/interfaces/term-policy.service.interface.ts
+++ b/src/modules/term-policy/interfaces/term-policy.service.interface.ts
@@ -19,7 +19,7 @@ import { TermPolicyCreateRequestDto } from '@modules/term-policy/dtos/request/te
 import { TermPolicyRemoveContentRequestDto } from '@modules/term-policy/dtos/request/term-policy.remove-content.request.dto';
 import { TermPolicyResponseDto } from '@modules/term-policy/dtos/response/term-policy.response.dto';
 import { TermPolicyUserAcceptanceResponseDto } from '@modules/term-policy/dtos/response/term-policy.user-acceptance.response.dto';
-import { EnumTermPolicyType } from '@prisma/client';
+import { EnumTermPolicyType, UserTermPolicy } from '@prisma/client';
 
 export interface ITermPolicyService {
     validateTermPolicyGuard(
@@ -42,6 +42,7 @@ export interface ITermPolicyService {
     userAccept(
         userId: string,
         { type }: TermPolicyAcceptRequestDto,
+        existingTermPolicies: UserTermPolicy,
         requestLog: IRequestLog
     ): Promise<IResponseReturn<void>>;
     createByAdmin(

--- a/src/modules/term-policy/repositories/term-policy.repository.ts
+++ b/src/modules/term-policy/repositories/term-policy.repository.ts
@@ -20,7 +20,7 @@ import {
     EnumTermPolicyType,
     EnumUserStatus,
     Prisma,
-    TermPolicy,
+    TermPolicy, UserTermPolicy,
 } from '@prisma/client';
 
 @Injectable()
@@ -142,13 +142,10 @@ export class TermPolicyRepository {
         userId: string,
         termPolicyId: string,
         type: EnumTermPolicyType,
+        userTermPolicies: UserTermPolicy,
         { ipAddress, userAgent }: IRequestLog
     ): Promise<ITermPolicyUserAcceptance> {
         const acceptedAt = this.helperService.dateCreate();
-        const user = await this.databaseService.user.findUniqueOrThrow({
-            where: { id: userId },
-            select: { termPolicy: true },
-        });
         const [userAcceptance] = await this.databaseService.$transaction([
             this.databaseService.termPolicyUserAcceptance.create({
                 data: {
@@ -170,7 +167,7 @@ export class TermPolicyRepository {
                 },
                 data: {
                     termPolicy: {
-                        ...(user.termPolicy as Prisma.JsonObject),
+                        ...userTermPolicies,
                         [type]: true,
                     },
                     activityLogs: {

--- a/src/modules/term-policy/repositories/term-policy.repository.ts
+++ b/src/modules/term-policy/repositories/term-policy.repository.ts
@@ -145,12 +145,17 @@ export class TermPolicyRepository {
         { ipAddress, userAgent }: IRequestLog
     ): Promise<ITermPolicyUserAcceptance> {
         const acceptedAt = this.helperService.dateCreate();
+        const user = await this.databaseService.user.findUniqueOrThrow({
+            where: { id: userId },
+            select: { termPolicy: true },
+        });
         const [userAcceptance] = await this.databaseService.$transaction([
             this.databaseService.termPolicyUserAcceptance.create({
                 data: {
                     acceptedAt,
                     userId,
                     termPolicyId,
+                    createdBy: userId,
                 },
                 include: {
                     termPolicy: true,
@@ -165,6 +170,7 @@ export class TermPolicyRepository {
                 },
                 data: {
                     termPolicy: {
+                        ...(user.termPolicy as Prisma.JsonObject),
                         [type]: true,
                     },
                     activityLogs: {

--- a/src/modules/term-policy/services/term-policy.service.ts
+++ b/src/modules/term-policy/services/term-policy.service.ts
@@ -42,6 +42,7 @@ import {
     EnumTermPolicyStatus,
     EnumTermPolicyType,
     TermPolicy,
+    UserTermPolicy,
 } from '@prisma/client';
 
 @Injectable()
@@ -142,6 +143,7 @@ export class TermPolicyService implements ITermPolicyService {
     async userAccept(
         userId: string,
         { type }: TermPolicyAcceptRequestDto,
+        existingTermPolicies: UserTermPolicy,
         requestLog: IRequestLog
     ): Promise<IResponseReturn<void>> {
         const policy =
@@ -170,6 +172,7 @@ export class TermPolicyService implements ITermPolicyService {
                 userId,
                 policy.id,
                 type,
+                existingTermPolicies,
                 requestLog
             );
 

--- a/src/modules/term-policy/services/term-policy.service.ts
+++ b/src/modules/term-policy/services/term-policy.service.ts
@@ -156,7 +156,7 @@ export class TermPolicyService implements ITermPolicyService {
         const exist =
             await this.termPolicyRepository.existAcceptanceByPolicyAndUser(
                 userId,
-                type
+                policy.id
             );
         if (exist) {
             throw new ConflictException({


### PR DESCRIPTION
## The issue:
Currently whenever we invoke the `repository.accept()`, we are overriding the content of `termPolicy` via:

```javascript
this.databaseService.user.update({
    //....
    data: {
        termPolicy: { // there we go
            [type]: true,
        },
  }
})
```

this leads to update on `termPolicy` like follows:
```
# Before Update:
{"cookies": false, "marketing": false, "privacy": true, "termsOfService": true}
# After Update (marketing accept)
{"marketing": true }
```

Looking around, looks like partial JSON field update, is not supported: 
1. https://github.com/prisma/prisma/discussions/3070
2. https://github.com/prisma/prisma/issues/5057
---
I don't like at-all the current fixes I made, however I did not found a prettier way, open to suggestions.
This workaround to me feels bad, it adds a new DB interactions, its not wrapped in a transactions, and its clearly a workaround for a not-supported feature.
