### PR TITLE
fix(headers): header x-correlation-id always undefined

### DIFF
--- a/src/common/response/dtos/response.dto.ts
+++ b/src/common/response/dtos/response.dto.ts
@@ -55,6 +55,22 @@ export class ResponseMetadataDto {
     })
     repoVersion: string;
 
+    @ApiProperty({
+        required: true,
+        description: 'Unique ID of this request',
+        example: '01966c9a-2b8d-7000-a957-4e1c1de0c8f7',
+        type: String,
+    })
+    requestId: string;
+
+    @ApiProperty({
+        required: true,
+        description: 'Correlation ID for distributed tracing',
+        example: '01966c9a-2b8d-7000-a957-4e1c1de0c8f7',
+        type: String,
+    })
+    correlationId: string;
+
     /* Allow additional properties for extensibility in metadata */
     [key: string]: unknown;
 }
@@ -97,6 +113,8 @@ export class ResponseDto<T> {
             path: '/api/v1/test/hello',
             version: '1',
             repoVersion: '1.0.0',
+            requestId: '01966c9a-2b8d-7000-a957-4e1c1de0c8f7',
+            correlationId: '01966c9a-2b8d-7000-a957-4e1c1de0c8f7',
         },
     })
     @Type(() => ResponseMetadataDto)

--- a/src/common/response/interceptors/response.interceptor.ts
+++ b/src/common/response/interceptors/response.interceptor.ts
@@ -1,10 +1,4 @@
-import {
-    CallHandler,
-    ExecutionContext,
-    HttpStatus,
-    Injectable,
-    NestInterceptor,
-} from '@nestjs/common';
+import { CallHandler, ExecutionContext, HttpStatus, Injectable, NestInterceptor, } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { HttpArgumentsHost } from '@nestjs/common/interfaces';
@@ -13,10 +7,7 @@ import { MessageService } from '@common/message/services/message.service';
 import { Reflector } from '@nestjs/core';
 import { IRequestApp } from '@common/request/interfaces/request.interface';
 import { ResponseMessagePathMetaKey } from '@common/response/constants/response.constant';
-import {
-    ResponseDto,
-    ResponseMetadataDto,
-} from '@common/response/dtos/response.dto';
+import { ResponseDto, ResponseMetadataDto, } from '@common/response/dtos/response.dto';
 import { ConfigService } from '@nestjs/config';
 import { HelperService } from '@common/helper/services/helper.service';
 import { IMessageProperties } from '@common/message/interfaces/message.interface';
@@ -161,6 +152,6 @@ export class ResponseInterceptor<T> implements NestInterceptor {
         response.setHeader('x-version', metadata.version);
         response.setHeader('x-repo-version', metadata.repoVersion);
         response.setHeader('x-request-id', String(metadata.requestId));
-        response.setHeader('x-correlation-id', String(metadata.correlation));
+        response.setHeader('x-correlation-id', String(metadata.correlationId));
     }
 }


### PR DESCRIPTION
`x-correlation-id` response header was always `undefined` due to a typo (`metadata.correlation` instead of `metadata.correlationId`). 
The root cause was that both fields were set via the `[key: string]: unknown index` signature, bypassing TypeScript type checking.

This PR:
1.  Declare `requestId: string` and `correlationId: string` as explicit typed fields on `ResponseMetadataDto`
2. Fix the typo: `metadata.correlation → metadata.correlationId` in ResponseInterceptor.setResponseHeaders()