### PR TITLE
fix(activity-log): losing property metadata-activity-log

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -72,13 +72,14 @@ module/
 @TermPolicyAcceptanceProtected(...)    // 2. Term policy
 @PolicyAbilityProtected({...})         // 3. CASL policy
 @RoleProtected(...)                    // 4. Role check
-@ActivityLog(...)                      // 5. Activity log
-@UserProtected()                       // 6. User status check
-@AuthJwtAccessProtected()              // 7. JWT validation
-@FeatureFlagProtected(...)             // 8. Feature flag
-@ApiKeyProtected()                     // 9. API key
-@HttpCode(HttpStatus.OK)               // 10. HTTP status (only when needed)
-@Get('/endpoint')                      // 11. HTTP method (always last)
+@UserProtected()                       // 5. User status check
+@AuthJwtAccessProtected()              // 6. JWT validation
+@FeatureFlagProtected(...)             // 7. Feature flag
+@ApiKeyProtected()                     // 8. API key
+@ActivityLog(...)                      // 9. Activity log
+@Response('key')                       // 10. Response / @ResponsePaging
+@HttpCode(HttpStatus.OK)               // 11. HTTP status (only when needed)
+@Get('/endpoint')                      // 12. HTTP method (always last)
 async method() {}
 ```
 

--- a/src/common/response/interfaces/response.interface.ts
+++ b/src/common/response/interfaces/response.interface.ts
@@ -34,7 +34,8 @@ export interface IResponseCacheOptions {
 
 /**
  * Mixin shape for controller return values that include activity log metadata.
- * When present, `ResponseInterceptor` forwards this to the `@ActivityLog` handler.
+ * When combined with `@ActivityLog`, place `@ActivityLog` above `@Response`
+ * so the activity log interceptor can read this field before the response is normalized.
  */
 export interface IResponseActivityLogReturn {
     metadataActivityLog?: IActivityLogMetadata;

--- a/src/modules/api-key/controllers/api-key.admin.controller.ts
+++ b/src/modules/api-key/controllers/api-key.admin.controller.ts
@@ -76,7 +76,6 @@ export class ApiKeyAdminController {
     constructor(private readonly apiKeyService: ApiKeyService) {}
 
     @ApiKeyAdminListDoc()
-    @ResponsePaging('apiKey.list')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
@@ -86,6 +85,7 @@ export class ApiKeyAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ResponsePaging('apiKey.list')
     @Get('/list')
     async list(
         @PaginationOffsetQuery({
@@ -104,17 +104,17 @@ export class ApiKeyAdminController {
     }
 
     @ApiKeyAdminCreateDoc()
-    @Response('apiKey.create')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
         action: [EnumPolicyAction.read, EnumPolicyAction.create],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminApiKeyCreate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminApiKeyCreate)
+    @Response('apiKey.create')
     @Post('/create')
     async create(
         @Body() body: ApiKeyCreateRequestDto
@@ -123,17 +123,17 @@ export class ApiKeyAdminController {
     }
 
     @ApiKeyAdminResetDoc()
-    @Response('apiKey.reset')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminApiKeyReset)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminApiKeyReset)
+    @Response('apiKey.reset')
     @Patch('/update/:apiKeyId/reset')
     async reset(
         @Param('apiKeyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -143,17 +143,17 @@ export class ApiKeyAdminController {
     }
 
     @ApiKeyAdminUpdateDoc()
-    @Response('apiKey.update')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminApiKeyUpdate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminApiKeyUpdate)
+    @Response('apiKey.update')
     @Put('/update/:apiKeyId')
     async update(
         @Body() body: ApiKeyUpdateRequestDto,
@@ -164,17 +164,17 @@ export class ApiKeyAdminController {
     }
 
     @ApiKeyAdminUpdateDateDoc()
-    @Response('apiKey.updateDate')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminApiKeyUpdateDate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminApiKeyUpdateDate)
+    @Response('apiKey.updateDate')
     @Put('/update/:apiKeyId/date')
     async updateDate(
         @Body() body: ApiKeyUpdateDateRequestDto,
@@ -185,17 +185,17 @@ export class ApiKeyAdminController {
     }
 
     @ApiKeyAdminUpdateStatusDoc()
-    @Response('apiKey.updateStatus')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminApiKeyUpdateStatus)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminApiKeyUpdateStatus)
+    @Response('apiKey.updateStatus')
     @Patch('/update/:apiKeyId/status')
     async updateStatus(
         @Param('apiKeyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -206,17 +206,17 @@ export class ApiKeyAdminController {
     }
 
     @ApiKeyAdminDeleteDoc()
-    @Response('apiKey.delete')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.apiKey,
         action: [EnumPolicyAction.read, EnumPolicyAction.delete],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminApiKeyDelete)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminApiKeyDelete)
+    @Response('apiKey.delete')
     @Delete('/delete/:apiKeyId')
     async delete(
         @Param('apiKeyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)

--- a/src/modules/device/controllers/device.admin.controller.ts
+++ b/src/modules/device/controllers/device.admin.controller.ts
@@ -67,7 +67,6 @@ export class DeviceAdminController {
     constructor(private readonly deviceService: DeviceService) {}
 
     @DeviceAdminListDoc()
-    @ResponsePaging('device.list')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected(
         {
@@ -83,6 +82,7 @@ export class DeviceAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ResponsePaging('device.list')
     @Get('/list')
     async list(
         @PaginationOffsetQuery()
@@ -103,7 +103,6 @@ export class DeviceAdminController {
     }
 
     @DeviceAdminRemoveDoc()
-    @Response('device.remove')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected(
         {
@@ -116,10 +115,11 @@ export class DeviceAdminController {
         }
     )
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminDeviceRemove)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminDeviceRemove)
+    @Response('device.remove')
     @HttpCode(HttpStatus.OK)
     @Delete('/remove/:deviceOwnershipId')
     async remove(

--- a/src/modules/role/controllers/role.admin.controller.ts
+++ b/src/modules/role/controllers/role.admin.controller.ts
@@ -65,7 +65,6 @@ export class RoleAdminController {
     constructor(private readonly roleService: RoleService) {}
 
     @RoleAdminListDoc()
-    @Response('role.list')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.role,
@@ -75,6 +74,7 @@ export class RoleAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @Response('role.list')
     @Get('/list')
     async list(
         @PaginationOffsetQuery({
@@ -91,7 +91,6 @@ export class RoleAdminController {
     }
 
     @RoleAdminGetDoc()
-    @Response('role.get')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.role,
@@ -101,6 +100,7 @@ export class RoleAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @Response('role.get')
     @Get('/get/:roleId')
     async get(
         @Param('roleId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -110,17 +110,17 @@ export class RoleAdminController {
     }
 
     @RoleAdminCreateDoc()
-    @Response('role.create')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.role,
         action: [EnumPolicyAction.read, EnumPolicyAction.create],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminRoleCreate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminRoleCreate)
+    @Response('role.create')
     @Post('/create')
     async create(
         @Body()
@@ -130,17 +130,17 @@ export class RoleAdminController {
     }
 
     @RoleAdminUpdateDoc()
-    @Response('role.update')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.role,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminRoleUpdate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminRoleUpdate)
+    @Response('role.update')
     @Put('/update/:roleId')
     async update(
         @Param('roleId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -152,17 +152,17 @@ export class RoleAdminController {
     }
 
     @RoleAdminDeleteDoc()
-    @Response('role.delete')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.role,
         action: [EnumPolicyAction.read, EnumPolicyAction.delete],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminRoleDelete)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminRoleDelete)
+    @Response('role.delete')
     @Delete('/delete/:roleId')
     async delete(
         @Param('roleId', RequestRequiredPipe, RequestIsValidObjectIdPipe)

--- a/src/modules/session/controllers/session.admin.controller.ts
+++ b/src/modules/session/controllers/session.admin.controller.ts
@@ -61,7 +61,6 @@ export class SessionAdminController {
     constructor(private readonly sessionService: SessionService) {}
 
     @SessionAdminListDoc()
-    @ResponsePaging('session.list')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected(
         {
@@ -77,6 +76,7 @@ export class SessionAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ResponsePaging('session.list')
     @Get('/list')
     async list(
         @PaginationOffsetQuery({
@@ -99,7 +99,6 @@ export class SessionAdminController {
     }
 
     @SessionAdminRevokeDoc()
-    @Response('session.revoke')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected(
         {
@@ -112,10 +111,11 @@ export class SessionAdminController {
         }
     )
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminSessionRevoke)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminSessionRevoke)
+    @Response('session.revoke')
     @Delete('/revoke/:sessionId')
     async revoke(
         @Param('userId', RequestRequiredPipe, RequestIsValidObjectIdPipe)

--- a/src/modules/term-policy/controllers/term-policy.admin.controller.ts
+++ b/src/modules/term-policy/controllers/term-policy.admin.controller.ts
@@ -84,7 +84,6 @@ export class TermPolicyAdminController {
     constructor(private readonly termPolicyService: TermPolicyService) {}
 
     @TermPolicyAdminListDoc()
-    @ResponsePaging('termPolicy.list')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
@@ -94,6 +93,7 @@ export class TermPolicyAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ResponsePaging('termPolicy.list')
     @Get('/list')
     async list(
         @PaginationOffsetQuery({
@@ -118,17 +118,17 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminCreateDoc()
-    @Response('termPolicy.create')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
         action: [EnumPolicyAction.read, EnumPolicyAction.create],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminTermPolicyCreate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminTermPolicyCreate)
+    @Response('termPolicy.create')
     @Post('/create')
     async create(
         @Body()
@@ -139,17 +139,17 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminDeleteDoc()
-    @Response('termPolicy.delete')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
         action: [EnumPolicyAction.read, EnumPolicyAction.delete],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminTermPolicyDelete)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminTermPolicyDelete)
+    @Response('termPolicy.delete')
     @Delete('/delete/:termPolicyId')
     async delete(
         @Param('termPolicyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -159,7 +159,6 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminGenerateContentPresignDoc()
-    @Response('termPolicy.generateContentPresign')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
@@ -173,6 +172,7 @@ export class TermPolicyAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @Response('termPolicy.generateContentPresign')
     @HttpCode(HttpStatus.OK)
     @Post('/generate/content/presign')
     async generate(
@@ -182,17 +182,17 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminUpdateContentDoc()
-    @Response('termPolicy.updateContent')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminTermPolicyUpdateContent)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminTermPolicyUpdateContent)
+    @Response('termPolicy.updateContent')
     @Put('/update/:termPolicyId/content/update')
     async updateContent(
         @Param('termPolicyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -209,17 +209,17 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminAddContentDoc()
-    @Response('termPolicy.addContent')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminTermPolicyAddContent)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminTermPolicyAddContent)
+    @Response('termPolicy.addContent')
     @Put('/update/:termPolicyId/content/add')
     async addContent(
         @Param('termPolicyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -236,17 +236,17 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminRemoveContentDoc()
-    @Response('termPolicy.removeContent')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminTermPolicyRemoveContent)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminTermPolicyRemoveContent)
+    @Response('termPolicy.removeContent')
     @Delete('/update/:termPolicyId/content/remove')
     async removeContent(
         @Param('termPolicyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -263,7 +263,6 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminGetContentDoc()
-    @Response('termPolicy.getContent')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
@@ -273,6 +272,7 @@ export class TermPolicyAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @Response('termPolicy.getContent')
     @HttpCode(HttpStatus.OK)
     @Post('/get/:termPolicyId/content/:language')
     async getContent(
@@ -284,17 +284,17 @@ export class TermPolicyAdminController {
     }
 
     @TermPolicyAdminPublishDoc()
-    @Response('termPolicy.publish')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.termPolicy,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminTermPolicyPublish)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminTermPolicyPublish)
+    @Response('termPolicy.publish')
     @Patch('/publish/:termPolicyId')
     async publish(
         @Param('termPolicyId', RequestRequiredPipe, RequestIsValidObjectIdPipe)

--- a/src/modules/user/controllers/user.admin.controller.ts
+++ b/src/modules/user/controllers/user.admin.controller.ts
@@ -97,7 +97,6 @@ export class UserAdminController {
     constructor(private readonly userService: UserService) {}
 
     @UserAdminListDoc()
-    @ResponsePaging('user.list')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
@@ -107,6 +106,7 @@ export class UserAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ResponsePaging('user.list')
     @Get('/list')
     async list(
         @PaginationOffsetQuery({
@@ -135,7 +135,6 @@ export class UserAdminController {
     }
 
     @UserAdminGetDoc()
-    @Response('user.get')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
@@ -145,6 +144,7 @@ export class UserAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @Response('user.get')
     @Get('/get/:userId')
     async get(
         @Param('userId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -154,17 +154,17 @@ export class UserAdminController {
     }
 
     @UserAdminCreateDoc()
-    @Response('user.create')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
         action: [EnumPolicyAction.read, EnumPolicyAction.create],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminUserCreate)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminUserCreate)
+    @Response('user.create')
     @Post('/create')
     async create(
         @Body()
@@ -186,17 +186,17 @@ export class UserAdminController {
     }
 
     @UserAdminUpdateStatusDoc()
-    @Response('user.updateStatus')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminUserUpdateStatus)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminUserUpdateStatus)
+    @Response('user.updateStatus')
     @Patch('/update/:userId/status')
     async updateStatus(
         @Param('userId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -220,17 +220,17 @@ export class UserAdminController {
     }
 
     @UserAdminUpdatePasswordDoc()
-    @Response('user.updatePassword')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminUserUpdatePassword)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminUserUpdatePassword)
+    @Response('user.updatePassword')
     @Put('/update/:userId/password')
     async updatePassword(
         @Param('userId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -252,17 +252,17 @@ export class UserAdminController {
     }
 
     @UserAdminResetTwoFactorDoc()
-    @Response('user.twoFactor.resetByAdmin')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
         action: [EnumPolicyAction.read, EnumPolicyAction.update],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminUserResetTwoFactor)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminUserResetTwoFactor)
+    @Response('user.twoFactor.resetByAdmin')
     @Patch('/update/:userId/2fa/reset')
     async resetTwoFactorByAdmin(
         @Param('userId', RequestRequiredPipe, RequestIsValidObjectIdPipe)
@@ -280,17 +280,17 @@ export class UserAdminController {
     }
 
     @UserAdminImportDoc()
-    @Response('user.import')
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
         action: [EnumPolicyAction.read, EnumPolicyAction.create],
     })
     @RoleProtected(EnumRoleType.admin)
-    @ActivityLog(EnumActivityLogAction.adminUserImport)
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ActivityLog(EnumActivityLogAction.adminUserImport)
+    @Response('user.import')
     @FileUploadSingle()
     @RequestTimeout('1m')
     @HttpCode(HttpStatus.OK)
@@ -317,7 +317,6 @@ export class UserAdminController {
     }
 
     @UserAdminExportDoc()
-    @ResponseFile()
     @TermPolicyAcceptanceProtected()
     @PolicyAbilityProtected({
         subject: EnumPolicySubject.user,
@@ -327,6 +326,7 @@ export class UserAdminController {
     @UserProtected()
     @AuthJwtAccessProtected()
     @ApiKeyProtected()
+    @ResponseFile()
     @HttpCode(HttpStatus.OK)
     @Post('/export')
     async export(


### PR DESCRIPTION
## Summary

Fixes missing `metadataActivityLog` values in activity log records on endpoints that use both `@ActivityLog(...)` and `@Response(...)`.

Services are already returning the correct shape — the data just wasn't reaching the activity logger:

```ts
return {
  data: createdUser,
  metadataActivityLog: { userId: createdUser.id },
};
```

## Problem

Both `@ActivityLog` and `@Response` register **interceptors** — middleware that wraps the request/response cycle. The order they're declared in code determines which one processes the response first.

TypeScript applies method decorators **bottom-to-top**: the bottom decorator is registered first and becomes the **outer** interceptor. Outer interceptors receive the response **last**, after all inner ones have already processed it.

When the decorators were ordered like this:

```ts
@Response(...)      // ← top → registered second → INNER → processes response first
@ActivityLog(...)   // ← bottom → registered first → OUTER → processes response last
```

The flow was:

```
Handler returns { data, metadataActivityLog }
  → ResponseInterceptor (inner) normalizes to { statusCode, message, data }  ← metadataActivityLog stripped
  → ActivityLogInterceptor (outer) reads the response                         ← field already gone
```

`ResponseInterceptor` strips `metadataActivityLog` when building the HTTP response, so by the time `ActivityLogInterceptor` tried to read it, it was already gone.

The action itself was still logged, but without the context metadata (e.g. which user was created, which API key was revoked, we basically loose track of which entity was the audit log related to).

## Reproduction

1. Call any mutation endpoint using both `@ActivityLog` and `@Response` — e.g. `POST /admin/user/create`.
2. Have the service return `metadataActivityLog` alongside `data`.
3. Inspect the stored activity-log record.

**Actual:** the record exists, but `metadataActivityLog` is empty.
**Expected:** the record includes the fields returned by the service.

## Fix

Reordered decorators so `@ActivityLog` is always **above** `@Response`:

```ts
@ActivityLog(...)   // ← top → registered second → INNER → processes response first ✓
@Response(...)      // ← bottom → registered first → OUTER → processes response last
```

Now the flow is:

```
Handler returns { data, metadataActivityLog }
  → ActivityLogInterceptor (inner) reads metadataActivityLog   ✓ still present
  → ResponseInterceptor (outer) normalizes the HTTP response
```

Clients never see `metadataActivityLog`  that hasn't changed, the activity log now stores it correctly.

## Additional: decorator ordering cleanup

`@ActivityLog` and `@Response` are interceptors, not auth guards. Leaving them in the middle of a guard stack made them hard to reason about.

This PR also moves both decorators to the **bottom of the stack**, after all auth guards, just before `@HttpCode` and the HTTP method:

```ts
@SomeDoc()
// auth guards ...
@ApiKeyProtected()
@ActivityLog(...)   // ← interceptors grouped at the bottom
@Response(...)
@HttpCode(...)
@Post('/endpoint')
```

`CLAUDE.md` has been updated to document this as the canonical decorator order.