### PR TITLE
fix(search): fix pagination search query build

### DIFF
--- a/src/common/pagination/pipes/pagination.search.pipe.ts
+++ b/src/common/pagination/pipes/pagination.search.pipe.ts
@@ -6,6 +6,7 @@ import {
     IPaginationQueryCursorParams,
     IPaginationQueryOffsetParams,
 } from '@common/pagination/interfaces/pagination.interface';
+import { Prisma } from '@generated/prisma-client';
 
 /**
  * Factory function to create PaginationSearchPipe that can perform search on available fields
@@ -50,15 +51,15 @@ export function PaginationSearchPipe(
          * Builds search object for database query
          * @param {string} search - Search string
          * @param {string[]} availableSearch - Array of searchable fields
-         * @returns {{ or: Record<string, { contains: string }>[] }} Query object for search
+         * @returns {{ OR: Array<Record<string, Prisma.StringFilter>> }} Query object for search
          */
         private buildSearchObject(
             search: string,
             availableSearch: string[]
-        ): { or: Record<string, { contains: string }>[] } {
+        ): { OR: Array<Record<string, Prisma.StringFilter>> } {
             return {
-                or: availableSearch.map(field => ({
-                    [field]: { contains: search },
+                OR: availableSearch.map(field => ({
+                    [field]: { contains: search, mode: Prisma.QueryMode.insensitive },
                 })),
             };
         }


### PR DESCRIPTION
### The issue

When performing a search on endpoints that support pagination with `availableSearch`, the API returns a 500 Internal Server Error.

You can replicate the issue by invoking any pagination endpoint with `availableSearch`:
`GET http://localhost:3000/api/v1/admin/user/list?search=admin`

And you will get:
```json
{
  "statusCode": 500,
  "message": "Internal Server Error",
  "metadata": {
    "language": "en",
    "timestamp": 1775335365939,
    "timezone": "Asia/Jakarta",
    "path": "/api/v1/admin/user/list",
    "version": "1",
    "repoVersion": "8.2.2",
    "requestId": "019d5a3b-dd1a-73cc-8b59-ca3b93673c13",
    "correlationId": "019d5a3b-dd1a-73cc-8b59-cf15457db9f9"
  }
}
```

### Root cause

The issue originates from an invalid Prisma query:

```
Unknown argument `or`. Did you mean `OR`?
```

The generated query uses a lowercase or instead of the expected uppercase OR, causing Prisma to reject the request.


The issue is in `buildSearchObject`:

```ts
/**
 * Builds search object for database query
 */
private buildSearchObject(
    search: string,
    availableSearch: string[]
): { or: Record<string, { contains: string }>[] } {
    return {
        or: availableSearch.map(field => ({
            [field]: { contains: search },
        })),
    };
}
```

### PR Changes
1. Replace or with OR to align with Prisma query requirements.
2. Ensure the generated query is valid and no longer throws runtime errors.
3. Search is now case-insensitive by default, improving usability and consistency across endpoints.