### PR TITLE
fix: jwks-server nginx listener on ipv6

### DIFF
--- a/ci/jwks-server/jwks.conf
+++ b/ci/jwks-server/jwks.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name localhost;
 
     # Hide nginx version from Server header and error pages


### PR DESCRIPTION
While running the project locally via `docker-compose` the healthcheck for `jwks-server` fails with:

```json
{"Start":"2026-06-24T08:33:14.115584177Z","End":"2026-06-24T08:33:14.140057052Z","ExitCode":1,"Output":"Connecting to localhost:80 ([::1]:80)\nwget: can't connect to remote host: Connection refused\n"}
```

Generally speaking, should be accepted to use both `localhost` and `127.0.0.1`.
This PR just enables nginx listener also for `localhost` on IPv6.