### PR TITLE
fix(hello): fix hello endpoint reference + healthcheck

### DIFF
--- a/ci/dockerfile
+++ b/ci/dockerfile
@@ -37,6 +37,6 @@ EXPOSE 3000
 
 # Add healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/hello
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/api/public/hello
 
 CMD ["pnpm", "start:prod"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
                     "--no-verbose",
                     "--tries=1",
                     "--spider",
-                    "http://localhost:3000/api/hello",
+                    "http://localhost:3000/api/public/hello",
                 ]
             interval: 30s
             timeout: 10s

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -419,7 +419,7 @@ Once your application is successfully running, you can access various endpoints 
 
 To verify everything is working correctly:
 
-1. **Test API**: Visit `http://localhost:3000/api/hello` for a simple API test
+1. **Test API**: Visit `http://localhost:3000/api/public/hello` for a simple API test
 2. **API Docs**: Ensure `http://localhost:3000/docs` loads the Swagger interface
 3. **Database Connection**: Check application logs for successful database connection
 4. **Redis Connection**: Verify Redis connection in the application logs

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -390,8 +390,8 @@ Routes excluded from auto-logging (defined in `logger.constant.ts`):
 
 ```typescript
 export const LoggerExcludedRoutes: string[] = [
-    '/api/hello',
-    '/api/hello/*',
+    '/api/public/hello',
+    '/api/public/hello/*',
     '/api/health',
     '/api/health/*',
     '/metrics',
@@ -416,8 +416,8 @@ To exclude additional routes, modify the constant in `src/common/logger/constant
 
 ```typescript
 export const LoggerExcludedRoutes: string[] = [
-    '/api/hello',
-    '/api/hello/*',
+    '/api/public/hello',
+    '/api/public/hello/*',
     '/api/health',
     '/api/health/*',
     '/metrics',

--- a/src/common/logger/constants/logger.constant.ts
+++ b/src/common/logger/constants/logger.constant.ts
@@ -7,8 +7,8 @@ export const LoggerAutoContext = 'LoggerAutoContext';
  * Routes excluded from auto-logging (health, docs, metrics). Supports wildcards.
  */
 export const LoggerExcludedRoutes: string[] = [
-    '/api/hello',
-    '/api/hello/*',
+    '/api/public/hello',
+    '/api/public/hello/*',
     '/api/health',
     '/api/health/*',
     '/metrics',


### PR DESCRIPTION
Small stupid changes:
1. Ignore logs on http hit on `public/hello` endpoint
2. Fix http endpoint health check used on docker
3. Small references on docs `.md`

One careful note: if we launch api via docker-container, `HTTP_HOST` env variable NEEDS to be `localhost` otherwise the health check set `http://localhost:3000` will fail.