### PR TITLE
fix(api): limit api docker-volume surface

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
         ports:
             - 3000:3000
         volumes:
-            - ./:/app/
+            - ./src:/app/src
+            - ./prisma:/app/prisma
+        env_file:
+            - .env.docker
         restart: on-failure
         networks:
             - app-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
             - ./src:/app/src
             - ./prisma:/app/prisma
         env_file:
-            - .env.docker
+            - .env
         restart: on-failure
         networks:
             - app-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
         volumes:
             - ./src:/app/src
             - ./prisma:/app/prisma
-        env_file:
-            - .env
+            - ./.env:/app/.env
         restart: on-failure
         networks:
             - app-network


### PR DESCRIPTION

Im used to switch between running the api "locally" vs "running it in container mode", im on Mac OS.

Previously, the `apis` service bind-mounted the full repository into the container:

```yaml
volumes:
  - ./:/app/
```

That mount also exposed the host machine’s `node_modules` inside the container (if you previously run pnpm install from host)
Even though `node_modules` was not copied during the Docker image build (thanks to .dockerignore), the runtime bind mount hid the image-built `/app/node_modules` and replaced it with the host version.

This caused pnpm to detect an incompatible `node_modules` layout/store and attempt to remove/recreate it. 
Since the container runs without an interactive TTY, pnpm aborted with:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
If you are running pnpm in CI, set the CI environment variable to "true", or set "confirmModulesPurge" to "false".
[ERROR] Command failed with exit code 1: /usr/local/bin/node /root/.cache/node/corepack/v1/pnpm/11.5.2/bin/pnpm.mjs install
```

## Root Cause

At build time, the image installs its own dependencies:

```dockerfile
RUN pnpm install --frozen-lockfile
```

So `/app/node_modules` exists in the image.

At runtime, however, Docker Compose mounted the host repository over `/app`. 
That hid the image’s `/app/node_modules` and exposed the host’s `node_modules` instead.

This can be incompatible because host dependencies may have a different pnpm store layout, symlink structure, OS, CPU architecture, or native binaries than the container.
